### PR TITLE
Add Gamemode Script and defaultWallpaper Variable

### DIFF
--- a/hosts/desktop/variables.nix
+++ b/hosts/desktop/variables.nix
@@ -8,6 +8,7 @@
     monitor = DP-2, 2560x1440@144, auto, auto;
     monitor = DP-3, 1920x1080@144, auto-up, auto;
   ";
+  defaultWallpaper = "hollow-knight.png";
 
   # Waybar Settings
   clock24h = true;

--- a/modules/core/stylix.nix
+++ b/modules/core/stylix.nix
@@ -6,7 +6,8 @@
   # Styling Options
   stylix = {
     enable = true;
-    image = ../../wallpapers/hollow-knight.png;
+    # not needed because wallpaper is managed by swww
+    # image = ../../wallpapers/hollow-knight.png;
     # catppuccin-mocha base16Scheme
     base16Scheme = {
       base00 = "1e1e2e";

--- a/modules/home/hyprland/config.nix
+++ b/modules/home/hyprland/config.nix
@@ -9,6 +9,7 @@
     browser
     terminal
     extraMonitorSettings
+    defaultWallpaper
     keyboardLayout
     ;
 in {
@@ -23,7 +24,7 @@ in {
         "nm-applet --indicator"
         "lxqt-policykit-agent"
         "pypr &"
-        "sleep 1.5 && swww img /home/${username}/Pictures/Wallpapers/hollow-knight.png"
+        "sleep 1.5 && swww img /home/${username}/pictures/wallpapers/${defaultWallpaper}"
       ];
 
       input = {
@@ -116,7 +117,7 @@ in {
         "$modifier SHIFT,D,exec,vesktop --enable-features=WebRTCPipeWireCapturer"
         "$modifier,O,exec,obs"
         "$modifier,C,exec,hyprpicker -a"
-        "$modifier,G,exec,gimp"
+        "$modifier,G,exec,gamemode"
         "$modifier,T,exec,thunar"
         "$modifier SHIFT,T,exec,pypr toggle thunar"
         "$modifier,M,exec,pavucontrol"

--- a/modules/home/scripts/default.nix
+++ b/modules/home/scripts/default.nix
@@ -1,20 +1,21 @@
 {
   pkgs,
   username,
+  host,
   ...
 }: {
   home.packages = [
     (import ./emopicker9000.nix {inherit pkgs;})
+    (import ./gamemode.nix {inherit pkgs host;})
     (import ./keybinds.nix {inherit pkgs;})
-    (import ./task-waybar.nix {inherit pkgs;})
-    (import ./squirtle.nix {inherit pkgs;})
     (import ./nvidia-offload.nix {inherit pkgs;})
-    (import ./wallsetter.nix {
-      inherit pkgs;
-      inherit username;
-    })
-    (import ./web-search.nix {inherit pkgs;})
     (import ./rofi-launcher.nix {inherit pkgs;})
     (import ./screenshootin.nix {inherit pkgs;})
+    (import ./squirtle.nix {inherit pkgs;})
+    (import ./task-waybar.nix {inherit pkgs;})
+    (import ./wallsetter.nix {
+      inherit pkgs username;
+    })
+    (import ./web-search.nix {inherit pkgs;})
   ];
 }

--- a/modules/home/scripts/gamemode.nix
+++ b/modules/home/scripts/gamemode.nix
@@ -5,6 +5,8 @@
 }: let
   inherit (import ../../../hosts/${host}/variables.nix) defaultWallpaper;
 in
+  # this script is sourced from JaKooLit's dotfiles:
+  # https://github.com/JaKooLit/Hyprland-Dots/blob/main/config/hypr/scripts/GameMode.sh
   pkgs.writeShellScriptBin "gamemode" ''
     HYPRGAMEMODE=$(hyprctl getoption animations:enabled | awk 'NR==1{print $2}')
     if [ "$HYPRGAMEMODE" = 1 ] ; then

--- a/modules/home/scripts/gamemode.nix
+++ b/modules/home/scripts/gamemode.nix
@@ -1,0 +1,41 @@
+{
+  pkgs,
+  host,
+  ...
+}: let
+  inherit (import ../../../hosts/${host}/variables.nix) defaultWallpaper;
+in
+  pkgs.writeShellScriptBin "gamemode" ''
+    HYPRGAMEMODE=$(hyprctl getoption animations:enabled | awk 'NR==1{print $2}')
+    if [ "$HYPRGAMEMODE" = 1 ] ; then
+        hyprctl --batch "\
+            keyword animations:enabled 0;\
+            keyword decoration:shadow:enabled 0;\
+            keyword decoration:blur:enabled 0;\
+            keyword general:gaps_in 0;\
+            keyword general:gaps_out 0;\
+            keyword general:border_size 1;\
+            keyword decoration:rounding 0"
+
+      hyprctl keyword "windowrule opacity 1 override 1 override 1 override, ^(.*)$"
+        swww kill
+        pkill waybar
+        notify-send "Gamemode: enabled"
+        exit
+    else
+      swww-daemon --format xrgb && swww img "$HOME/pictures/wallpapers/${defaultWallpaper}" &
+      sleep 0.5
+      hyprctl --batch "\
+          keyword animations:enabled 1;\
+          keyword decoration:shadow:enabled 1;\
+          keyword decoration:blur:enabled 1;\
+          keyword general:gaps_in 6;\
+          keyword general:gaps_out 8;\
+          keyword general:border_size 2;\
+          keyword decoration:rounding 10"
+        waybar &
+        notify-send "Gamemode: disabled"
+        exit
+    fi
+    hyprctl reload
+  ''


### PR DESCRIPTION
This adds a gamemode toggle with mod + G, replacing the previous bind for gimp. Also added a defaultWallpaper variable to make it easier to switch wallpapers. Note that this commit removes stylix.image (stylix wallpaper) because we manage our wallpapers with swww.

gamemode script from [jakoolit's dotfiles](https://github.com/JaKooLit/Hyprland-Dots/blob/main/config/hypr/scripts/GameMode.sh)